### PR TITLE
Move knowledge base to ZBMed subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This knowledge base is a collection of documents and references important to the
 
 ## Contributing to the Knowledge Base
 
-If you want to contribtute to the Knowledge base, please see the [02-contributing.md](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/docs/_Getting-Started/02-contributing.md) file, and be sure to add yourself to the [03-contributors.md](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/docs/_Getting-Started/03-contributors.md) file.
+If you want to contribtute to the Knowledge base, please see the [02-contributing.md](https://github.com/NFDI4Microbiota/blob/main/docs/_Getting-Started/02-contributing.md) file, and be sure to add yourself to the [03-contributors.md](https://github.com/NFDI4Microbiota/blob/main/docs/_Getting-Started/03-contributors.md) file.
 
 ## License
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: /nfdi4microbiota-knowledge-base
+#baseurl: /nfdi4microbiota-knowledge-base
 
 excerpts:
   # Displays or hides post excerpts from home layout post listing.

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-#baseurl: /nfdi4microbiota-knowledge-base
+#baseurl: 
 
 excerpts:
   # Displays or hides post excerpts from home layout post listing.

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -14,7 +14,7 @@
     </div>
 
     <a class="navbar-brand p-0 me-0 me-lg-2" href="https://nfdi4microbiota.de/" aria-label="Bootstrap">
-      <img height="45" width="70" src="/nfdi4microbiota-knowledge-base/assets/img/nfdi4microbiota_Logo_new.png"></img>
+      <img height="45" width="70" src="/assets/img/nfdi4microbiota_Logo_new.png"></img>
       <!-- <svg xmlns="http://www.w3.org/2000/svg" width="40" height="32" class="d-block my-1" viewBox="0 0 118 94"
         role="img">
         <title>NFDI4Microbiota</title>
@@ -48,7 +48,7 @@
         <ul class="navbar-nav flex-row flex-wrap bd-navbar-nav">
           <li class="nav-item col-6 col-lg-auto">
             <a class="nav-link py-2 px-0 px-lg-2 active" aria-current="true"
-              href="/nfdi4microbiota-knowledge-base/">KNOWLEDGE BASE</a>
+              href="/">KNOWLEDGE BASE</a>
           </li>
         </ul>
 
@@ -56,7 +56,7 @@
 
         <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link py-2 px-0 px-lg-2" href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base" target="_blank" rel="noopener">
+            <a class="nav-link py-2 px-0 px-lg-2" href="https://github.com/NFDI4Microbiota" target="_blank" rel="noopener">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="navbar-nav-svg"
                 viewBox="0 0 512 499.36" role="img">
                 <title>GitHub</title>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,17 +9,17 @@
 
     <title>The NFDI4Microbiota Knowledge Base</title>
 
-    <script src="/nfdi4microbiota-knowledge-base/assets/js/color-modes.js"></script>
+    <script src="/assets/js/color-modes.js"></script>
 
-    <link rel="stylesheet" href="/nfdi4microbiota-knowledge-base/assets/css/docsearch.css">
+    <link rel="stylesheet" href="/assets/css/docsearch.css">
 
-    <link href="/nfdi4microbiota-knowledge-base/assets/css/bootstrap53..min.css" rel="stylesheet">
+    <link href="/assets/css/bootstrap53..min.css" rel="stylesheet">
 
-    <link href="/nfdi4microbiota-knowledge-base/assets/css/docs53.css" rel="stylesheet">
+    <link href="/assets/css/docs53.css" rel="stylesheet">
 
 
 
-    <script defer src="/nfdi4microbiota-knowledge-base/assets/js/usefathom.js" data-site="ITUSEYJG"></script>
+    <script defer src="/assets/js/usefathom.js" data-site="ITUSEYJG"></script>
     <script>
         window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) }; ga.l = +new Date;
         ga('create', 'UA-146052-10', 'getbootstrap.com');
@@ -169,7 +169,7 @@
             <div class="bd-intro pt-2 ps-lg-2">
                 <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
                     <div class="mb-3 mb-md-0 d-flex text-nowrap"><a class="btn btn-sm btn-bd-light rounded-2"
-                            href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/{{ git_url }}.md"
+                            href="https://github.com/NFDI4Microbiota/blob/main/{{ git_url }}.md"
                             title="View and edit this file on GitHub" target="_blank" rel="noopener">
                             View on GitHub
                         </a>
@@ -231,17 +231,17 @@
 
     {% include footer.html %}
 
-    <script src="/nfdi4microbiota-knowledge-base/assets/js/boostrap53.bundle.min.js"></script>
+    <script src="/assets/js/boostrap53.bundle.min.js"></script>
 
 
-    <script src="/nfdi4microbiota-knowledge-base/assets/js/docsearch.js"></script>
+    <script src="/assets/js/docsearch.js"></script>
 
-    <script src="/nfdi4microbiota-knowledge-base/assets/js/bundle.sdk.js"></script>
+    <script src="/assets/js/bundle.sdk.js"></script>
 
-    <script src="/nfdi4microbiota-knowledge-base/assets/js/doc53.js"></script>
+    <script src="/assets/js/doc53.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
     crossorigin="anonymous"></script>
-    <script src="/nfdi4microbiota-knowledge-base/assets/js/main.js"></script>
+    <script src="/assets/js/main.js"></script>
 
     <script>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -169,7 +169,7 @@
             <div class="bd-intro pt-2 ps-lg-2">
                 <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
                     <div class="mb-3 mb-md-0 d-flex text-nowrap"><a class="btn btn-sm btn-bd-light rounded-2"
-                            href="https://github.com/NFDI4Microbiota/blob/main/{{ git_url }}.md"
+                            href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/{{ git_url }}.md"
                             title="View and edit this file on GitHub" target="_blank" rel="noopener">
                             View on GitHub
                         </a>

--- a/_layouts/default_bkp.html
+++ b/_layouts/default_bkp.html
@@ -66,7 +66,7 @@
         <!-- The second argument for replace_first should be the url of the homepage-->
         {% assign git_url = page.url | replace_first:'/', 'docs/_Getting-Started/01-introduction' %}
         {% endif %}
-        <a href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/{{ git_url }}.md"
+        <a href="https://github.com/NFDI4Microbiota/blob/main/{{ git_url }}.md"
           class="edit">
           <i class="fa-solid fa-pen"></i> Edit this page
         </a>

--- a/_layouts/docs_home.html
+++ b/_layouts/docs_home.html
@@ -36,7 +36,7 @@ layout: default
         {% assign git_url = page.url | replace_first:'/', 'docs/_Getting-Started/01-introduction' %}
       {% endif %}
       <a 
-        href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/{{ git_url }}.md"
+        href="https://github.com/NFDI4Microbiota/blob/main/{{ git_url }}.md"
         class="edit"
       >
         <i class="fa-solid fa-pen"></i> Edit this page

--- a/docs/_Getting-Started/01-introduction.md
+++ b/docs/_Getting-Started/01-introduction.md
@@ -12,7 +12,7 @@ permalink: /
 <!-- <div class="bd-intro pt-2 ps-lg-2">
                 <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
                     <div class="mb-3 mb-md-0 d-flex text-nowrap"><a class="btn btn-sm btn-bd-light rounded-2"
-                            href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base"
+                            href="https://github.com/NFDI4Microbiota"
                             title="View and edit this file on GitHub" target="_blank" rel="noopener">
                             View on GitHub
                         </a>
@@ -47,8 +47,8 @@ achieving the look-up for the desired document.
 ## How to contribute to this resource
 
 The files are hosted at a [repo on
-GitHub](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base). You
+GitHub](https://github.com/NFDI4Microbiota). You
 can contribute by suggesting new content in [an
-issue](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/issues)
+issue](https://github.com/NFDI4Microbiota/issues)
 or directly proposed changes using a [pull
-request](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/pulls).
+request](https://github.com/NFDI4Microbiota/pulls).

--- a/docs/_Getting-Started/02-contributing.md
+++ b/docs/_Getting-Started/02-contributing.md
@@ -15,11 +15,11 @@ The main steps a user must follow to contribute to the Knowledge Base are:
 2. Make changes to files in the repository:
     - Edit existing files *or*
     - Create new files
-3. Add your name to the [03-contributors.md](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/docs/_Getting-Started/03-contributors.md) file
+3. Add your name to the [03-contributors.md](https://github.com/NFDI4Microbiota/blob/main/docs/_Getting-Started/03-contributors.md) file
 
 ## Create a GitHub account
 
-Users will need a GitHub account if they wish to contribute to the Knowledge Base. If you do not already have an account, go to the GitHub [homepage](https://github.com/) and click the `Sign Up` button to create one. Then follow the instructions. Once you have created an account, and signed in, go to the [Knowledge Base repository](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base.github.io)
+Users will need a GitHub account if they wish to contribute to the Knowledge Base. If you do not already have an account, go to the GitHub [homepage](https://github.com/) and click the `Sign Up` button to create one. Then follow the instructions. Once you have created an account, and signed in, go to the [Knowledge Base repository](https://github.com/NFDI4Microbiota.github.io)
 
 ## Make changes to the repository
 
@@ -56,7 +56,7 @@ A [GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issue
 
 To create a new issue:
 
-1. Go to the [issues page](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base.github.io/issues)
+1. Go to the [issues page](https://github.com/NFDI4Microbiota.github.io/issues)
 2. Click the `New issue` button
 3. Add the title (the name of the suggested page) and add a description of what you want to include in the new page
 4. Assign the issue to `Mahdi Robbani`
@@ -66,7 +66,7 @@ To create a new issue:
 
 ## Add your name to the CONTRIBUTORS file
 
-We appreciate your contribution! Please add your name to the [03-contributors.md](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/main/docs/_Getting-Started/03-contributors.md) file.
+We appreciate your contribution! Please add your name to the [03-contributors.md](https://github.com/NFDI4Microbiota/blob/main/docs/_Getting-Started/03-contributors.md) file.
 
 
 ## Contribution Rules

--- a/docs/_Reproducible-Data-Analysis/02-workflows.md
+++ b/docs/_Reproducible-Data-Analysis/02-workflows.md
@@ -12,7 +12,7 @@ This page should give an overview of suggested standards for workflows. Not all 
 
 ## FAIR Principles for Data management
 
-In NFDI4Microbiota, we aim to follow the FAIR principles for data management (see [here](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Research-Data-Management/04-fair) for more details).
+In NFDI4Microbiota, we aim to follow the FAIR principles for data management (see [here](https://nfdi4microbiota.github.io/Research-Data-Management/04-fair) for more details).
 In essence, data should be Findable, Accessible, Interoperable, and Reusable.
 For workflows this means, data and/or results in the form of processed data should (if possible):
 

--- a/docs/_Research-Data-Management/02-rdm.md
+++ b/docs/_Research-Data-Management/02-rdm.md
@@ -10,7 +10,7 @@ Research Data Management (RDM) is a series of measures that need to be taken dur
 ## Research data life cycle
 The research data life cycle is a model that illustrates the steps of RDM and describes how data should ideally flow through a research project to ensure successful data curation and preservation {% cite NTU_LibGuides_RD_life_cycle bobrov_2021 %}. The research data life cycle can be illustrated as follow: 
 
-![Research data life cycle](/nfdi4microbiota-knowledge-base/assets/img/research_data_life_cycle.png)
+![Research data life cycle](/assets/img/research_data_life_cycle.png)
 
 ## Benefits of RDM
 

--- a/docs/_Research-Data-Management/04-fair.md
+++ b/docs/_Research-Data-Management/04-fair.md
@@ -12,7 +12,7 @@ The FAIR data principles are a concise and measurable set of principles that may
 * Enhancing the ability of machines to automatically find and use data.
 * Supporting the reuse of data by individuals, which “is essential to the advancement of research and clinical practice”.
 
-![FAIR Data Principles](/nfdi4microbiota-knowledge-base/assets/img/fair_principles_cropped.png)
+![FAIR Data Principles](/assets/img/fair_principles_cropped.png)
 
 The principles {% cite wilkinson_2016 go_fair_2022 %} are reproduced below:
 

--- a/docs/_Research-Data-Management/12-eln.md
+++ b/docs/_Research-Data-Management/12-eln.md
@@ -24,7 +24,7 @@ ELNs are not data publishing platforms and are not suitable for storing large fi
 ELNs increase the efficiency of everyday tasks by providing time-saving features and functions such as search and filtering {% cite vandendorpe_nd %}. ELNs also take advantage of standardisation {% cite rathmann_2021 %}: they have the ability to create templates such as protocols, Standard Operating Procedures (SOPs) and workflows. This facilitates data documentation with metadata {% cite vandendorpe_nd %} and supports clarity and organisation of data and protocols {% cite n4m_wc_elns_2023 %}. ELNs also provide ubiquitous access {% cite vandendorpe_nd %}: protocols, observations, notes and other data can be entered using a computer or mobile device {% cite lma_rdmwg %}.
 
 ## Connection to a digital research environment
-ELNs are linked to a digital research environment {% cite vandendorpe_nd %}, for example through their import and export capabilities {% cite bobrov_2021 %}. ELNs can also provide seamless interfaces to other programmes, such as Application Programming Interfaces (APIs) {% cite bobrov_2021 %}. This networked aspect of ELNs enables them to play a central role in an institution's [Research Data Management](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Research-Data-Management/02-rdm) (RDM) strategy. Indeed, ELNs can be linked and contribute to almost each step of the research data lifecycle:
+ELNs are linked to a digital research environment {% cite vandendorpe_nd %}, for example through their import and export capabilities {% cite bobrov_2021 %}. ELNs can also provide seamless interfaces to other programmes, such as Application Programming Interfaces (APIs) {% cite bobrov_2021 %}. This networked aspect of ELNs enables them to play a central role in an institution's [Research Data Management](https://nfdi4microbiota.github.io/Research-Data-Management/02-rdm) (RDM) strategy. Indeed, ELNs can be linked and contribute to almost each step of the research data lifecycle:
 
 * **Data collection:** ELNs can automatically record results from measuring instruments {% cite rathmann_2021 vandendorpe_2020 %} and retrieve data from databases for actively used data {% cite assmann_2022 Krause_2016 %}.
 
@@ -38,7 +38,7 @@ ELNs also facilitate publishing by providing a means to prepare research data fo
 * **Data discovery and reuse:** ELNs can prove provenance {% cite lma_rdmwg %}.
 
 ## Complying to the FAIR Data Principles
-ELNs support the [FAIR Data Principles](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Research-Data-Management/04-fair) {% cite lma_rdmwg %}:
+ELNs support the [FAIR Data Principles](https://nfdi4microbiota.github.io/Research-Data-Management/04-fair) {% cite lma_rdmwg %}:
 
 * **Findability:** ELNs support findability by providing comprehensive search capabilities (e.g. database search, full-text search, conditional search), by supporting the assignment of metadata and tags (e.g. through extraction from documents), by assigning persistent identifiers such as the Digital Object Identifier (DOI) and by linking to data repositories and digital preservation systems {% cite bobrov_2021 %}.
 

--- a/docs/_Research-Data-Management/25-licenses.md
+++ b/docs/_Research-Data-Management/25-licenses.md
@@ -43,7 +43,7 @@ There are different versions of CC that consist of the core license with further
 - **Non-derivative (ND):** No derivatives or adaptations of the work are permitted (not compatible with share-alike).
 
 
-![ccsprectrum](/nfdi4microbiota-knowledge-base/assets/img/Creative_commons_license_spectrum.svg)
+![ccsprectrum](/assets/img/Creative_commons_license_spectrum.svg)
 
 ([Source](https://commons.wikimedia.org/wiki/File:Creative_commons_license_spectrum.svg), CC-BY Shaddim; original CC license symbols by Creative Commons)
 

--- a/docs/_Research-Data-Management/26-data-reuse.md
+++ b/docs/_Research-Data-Management/26-data-reuse.md
@@ -10,7 +10,7 @@ redirect_from: /Research-Data-Management
 
 Making data reusable benefits researchers who publish their data, researchers who reuse data, and society. 
 
-Researchers who publish their data see an increase in their scientific reputation, citations and collaborations {% cite rehwald_2022 pauls_2023 %}. In addition, researchers who publish their data not only comply with the [FAIR Data Principles](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Research-Data-Management/04-fair), but also avoid bias in the body of evidence {% cite IOM_2015 %}, increase transparency and thus trust in research {% cite engelhardt_2022 rehwald_2022 pauls_2023 %}. Finally, by sharing their resources and perspectives, researchers who publish their data enable other researchers to build on their work, accelerating scientific discovery {% cite engelhardt_2022 IOM_2015 rehwald_2022 %}.
+Researchers who publish their data see an increase in their scientific reputation, citations and collaborations {% cite rehwald_2022 pauls_2023 %}. In addition, researchers who publish their data not only comply with the [FAIR Data Principles](https://nfdi4microbiota.github.io/Research-Data-Management/04-fair), but also avoid bias in the body of evidence {% cite IOM_2015 %}, increase transparency and thus trust in research {% cite engelhardt_2022 rehwald_2022 pauls_2023 %}. Finally, by sharing their resources and perspectives, researchers who publish their data enable other researchers to build on their work, accelerating scientific discovery {% cite engelhardt_2022 IOM_2015 rehwald_2022 %}.
 
 Researchers can recycle unique data by performing secondary analyses to answer new research questions and/or with new methods {% cite rehwald_2022 pauls_2023 %}. Reusing data in this way saves resources such as time, energy and money {% cite engelhardt_2022 FSD rehwald_2022 pauls_2023 %}. Data reuse also increases collaboration and, over time, enables the comparison of different samples {% cite rehwald_2022 pauls_2023 %}. Indeed, data reuse is essential for interdisciplinary experiments and cross-cutting research approaches {% cite pavone_2020 %}.
 
@@ -23,7 +23,7 @@ For researchers who publish their data, preparing datasets for reuse is time-con
 For researchers reusing data, there are risks such as unknown quality and denormalisation (i.e. "the same data is stored multiple times in the same database under different names/identifiers"). There is also the challenge of comparing and integrating datasets from different sources {% cite sielemann_2020 %}.
 
 # Relevant licenses and terms of use
-See [Licenses](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Research-Data-Management/25-licenses).
+See [Licenses](https://nfdi4microbiota.github.io/Research-Data-Management/25-licenses).
 
 # Criteria for selection trustworthy datasets
 
@@ -89,7 +89,7 @@ Below is a list of criteria for selecting trustworthy datasets {% cite bres_2022
 * [gesisDataSearch](https://datasearch.gesis.org/start)
 
 ### Services where data can be published
-* **Interdisciplinary and [discipline-specific](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Research-Data-Management/22-data-repositories) repositories**
+* **Interdisciplinary and [discipline-specific](https://nfdi4microbiota.github.io/Research-Data-Management/22-data-repositories) repositories**
 * **Data reports**
 * **Data journals** (see e.g. [here](https://www.forschungsdaten.org/index.php/Data_Journals))
 

--- a/utils/check_links.py
+++ b/utils/check_links.py
@@ -5,7 +5,7 @@ from sys import exit
 from typing import List
 
 BASE_URL = "https://nfdi4microbiota.github.io"
-HOME_URL = f"{BASE_URL}/nfdi4microbiota-knowledge-base/"
+HOME_URL = f"{BASE_URL}/"
 
 def get_page_urls(url: str):
     response = requests.get(url)


### PR DESCRIPTION
The NFDI knowledge base will be moved from `https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/` to `knowledgebase.nfdi4microbiota.de/`

This pull request contains the required url and url generation changes.