### PR TITLE
disclaimer for bio.tools ontology domain added to 04-resources and 02-toolsurvey to indicate upcoming changes

### DIFF
--- a/docs/_Reproducible-Data-Analysis/04-resources.md
+++ b/docs/_Reproducible-Data-Analysis/04-resources.md
@@ -49,7 +49,7 @@ Modelling and simulation, Optimisation and refinement, Prediction and recognitio
 
 ## Disclaimer: Changes in the tool display
 
-We recently created an [NFDI4Microbiota domain on bio.tools](https://nfdi4microbiota.bio.tools) and we will soon be displaying all the tools that NFDI4Microbiota created as well as the ones that NFDI4Microbiota consortium members endorse and highly recommend.
+We recently created a [NFDI4Microbiota domain](https://nfdi4microbiota.bio.tools) on [the life sciences software registry bio.tools](https://bio.tools) and we will soon be displaying all the tools that NFDI4Microbiota created as well as the ones that NFDI4Microbiota consortium members endorse and highly recommend.
 
 Thank you for your patience while we sort out editing rights and collection labels.
 Below you can browse tool recommendations from our consortium members.

--- a/docs/_Reproducible-Data-Analysis/04-resources.md
+++ b/docs/_Reproducible-Data-Analysis/04-resources.md
@@ -47,6 +47,12 @@ Modelling and simulation, Optimisation and refinement, Prediction and recognitio
 
 ---
 
+## Disclaimer: Changes in the tool display
+
+We recently created an [NFDI4Microbiota domain on bio.tools](https://nfdi4microbiota.bio.tools) and we will soon be displaying all the tools that NFDI4Microbiota created as well as the ones that NFDI4Microbiota consortium members endorse and highly recommend.
+
+Thank you for your patience while we sort out editing rights and collection labels.
+Below you can browse tool recommendations from our consortium members.
 
 
 ## bakta

--- a/docs/_Software-Development/02-toolsurvey.md
+++ b/docs/_Software-Development/02-toolsurvey.md
@@ -9,6 +9,13 @@ The following data is compiled from a questionnaire of Q4 2022 and is targeted a
 
 The goal is to gather this information centrally in NFDI4Microbiota to assess the span of tools and derive consortium-wide guidelines for the tightest integration possible.
 
+## Disclaimer: Changes in the tool display
+
+We recently created an [NFDI4Microbiota domain on bio.tools](https://nfdi4microbiota.bio.tools) and we will soon be displaying all the tools that NFDI4Microbiota created as well as the ones that NFDI4Microbiota consortium members endorse and highly recommend.
+
+Thank you for your patience while we sort out editing rights and collection labels.  
+In the meantime, browse our tools below and find more [recommendations for resources on reproducible data analysis](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Reproducible-Data-Analysis/04-resources).
+
 ## Applications
 ### checkM2 (EMBL) 
 

--- a/docs/_Software-Development/02-toolsurvey.md
+++ b/docs/_Software-Development/02-toolsurvey.md
@@ -11,7 +11,7 @@ The goal is to gather this information centrally in NFDI4Microbiota to assess th
 
 ## Disclaimer: Changes in the tool display
 
-We recently created an [NFDI4Microbiota domain on bio.tools](https://nfdi4microbiota.bio.tools) and we will soon be displaying all the tools that NFDI4Microbiota created as well as the ones that NFDI4Microbiota consortium members endorse and highly recommend.
+We recently created a [NFDI4Microbiota domain](https://nfdi4microbiota.bio.tools) on [the life sciences software registry bio.tools](https://bio.tools) and we will soon be displaying all the tools that NFDI4Microbiota created as well as the ones that NFDI4Microbiota consortium members endorse and highly recommend.
 
 Thank you for your patience while we sort out editing rights and collection labels.  
 In the meantime, browse our tools below and find more [recommendations for resources on reproducible data analysis](https://nfdi4microbiota.github.io/nfdi4microbiota-knowledge-base/Reproducible-Data-Analysis/04-resources).


### PR DESCRIPTION
We now have a domain that lists tools endorsed by the consortium at https://nfdi4microbiota.bio.tools
For now, only cpauvert can edit that domain (maybe this will change with improved rights).
We also have a collection https://bio.tools/t?collectionID=%22NFDI4Microbiota%22, and all tools from this collection will display a small "NFDI4Microbiota" label. We can add more labels to distinguish between tools funded/ created by NFDI4Microbiota members and recommendations/ endorsement of usage. 