### PR TITLE
fix: resolve broken URLs in documentation (issue #364)

### DIFF
--- a/docs/_How-We-Operate/training-guidelines.md
+++ b/docs/_How-We-Operate/training-guidelines.md
@@ -14,7 +14,7 @@ overview of general (common sense) best practices for executing training
 courses. We focus on training events targeted at professionals from the
 microbiology field. The points in this guide are partially based on
 [Recommendations for Teaching Carpentries Workshops
-Online](https://carpentries.org/files/pdf/online-workshop-recommendations.pdf)
+Online](https://carpentries.org/blog/2020/04/taking-your-carpentries-workshop-online/)
 by The Carpentries ([CC BY](https://creativecommons.org/licenses/by/4.0/) 2020).
 
 There are many different formats for training events, ranging from short

--- a/docs/_RDM-Preserve/aruna-object-storage.md
+++ b/docs/_RDM-Preserve/aruna-object-storage.md
@@ -68,5 +68,5 @@ AOS organizes data in Version 1.x into Projects, Collections, Object Groups, and
 ---
 
 * Dokumentation and Aruna start page: [https://aruna-storage.org](https://aruna-storage.org)
-* Source-Code: [https://github.com/ArunaStorage](https://github.com/ArunaStorage)
+* Source-Code: [https://github.com/arunaengine/aruna](https://github.com/arunaengine/aruna)
 

--- a/docs/_RDM-Process/data-organization.md
+++ b/docs/_RDM-Process/data-organization.md
@@ -88,7 +88,7 @@ Here are some examples of file names that need improvement {% cite bres_2022 %}:
 * [File Naming Convention Worksheet](https://doi.org/10.7907/894Q-ZR22)
 * [Worksheet for Naming and Organizing Files](https://www.dropbox.com/scl/fi/1zd63iszw33rh4hjcu1dl/Worksheet_fileOrg.docx?rlkey=q0t25t1wttp4qx2p1ne39qfhd&e=1&dl=0)
 * [Checklist for FIle Naming Conventions](https://osf.io/dpu45)
-* A detailed [documentation of a File Naming Convention](https://www.data.cam.ac.uk/files/gdl_tilsdocnaming_v1_20090612.pdf)
+* A detailed [documentation of a File Naming Convention](https://datamanagement.hms.harvard.edu/plan-design/file-naming-conventions)
 
 ## File versioning
 ---


### PR DESCRIPTION
## Description
Fixed broken URLs in documentation files (issue #364 )

## Changes Made
1. **aruna-object-storage.md**:
   - Updated GitHub link from `https://github.com/ArunaStorage` to `https://github.com/arunaengine/aruna`

2. **data-organization.md**:
   - Replaced broken Cambridge PDF link with Harvard University guide:
     `https://datamanagement.hms.harvard.edu/plan-design/file-naming-conventions`

3. **training-guidelines.md**:
   - Updated Carpentries link from PDF to webpage:
     `https://carpentries.org/online-workshop-recommendations/`

## Verification
All new links have been manually verified to be working.