### PR TITLE
adding new pages keeping the new refactoring system in mind, documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -148,6 +148,7 @@ collections:
     order:
      - glossary.md
      - external-training-resources.md
+     - host-associated-isolates.md
   How-We-Operate:
     output: true
     permalink: /:collection/:name.html

--- a/docs/_Getting-Started/contributing.md
+++ b/docs/_Getting-Started/contributing.md
@@ -67,6 +67,9 @@ To create a new issue:
 
 [Here](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) is a guide on creating issues on GitHub if you need further help.
 
+*Note: Currently all microbiology related files and pages are collected in the [Resources Collection]( _Resources) until a more suitable Collection is created for these.*
+
+
 ## Cite Sources
 
 ---

--- a/docs/_Getting-Started/contributing.md
+++ b/docs/_Getting-Started/contributing.md
@@ -64,6 +64,9 @@ To create a new issue:
 3. Add the title (the name of the suggested page) and add a description of what you want to include in the new page
 4. Assign the issue to `Mahdi Robbani`
 5. Click the `Submit new issue` button
+6. Your request will be reviewed and discussed among the git-committee-members of NFDI4Microbiota.
+7. When accepted, a new page/ new file will be created and added to the appropriate collection.
+8. The collection may be reordered in [this config.yaml file](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/blob/9132ef3bfc9f28fcf8eb293d93fc4507eec87a9d/_config.yml#L48) as described below. 
 
 [Here](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) is a guide on creating issues on GitHub if you need further help.
 


### PR DESCRIPTION
Hey @mahdi-robbani and @nkurtys , 

I've added a note  in the contribution file that microbiology content is currently featured in the "Resource Collection".
I've also noticed that one of the new pages created by Katerina it didn't show up on the dev or main view of the KB.

This pull-request resolves and points out a few issues:

1. potential issue: the new host-isolate file was merged directly in main rather than dev > FYI, if there is an error somewhere.
2. I've added the file to the collection config.yml under "Resources". After resolving any conflicts and merge issues, the content should appear (hopefully).
3. I'vee added descriptions in the contributing.md on how to add new pages.
@mahdi-robbani and @nkurtys please review if the steps are okay and resolve/ rephrase anything or change the procedure?

4. Does this mean, we have to manually add new pages to the collections every time too, for them to show up or do you want to create an issue for "automatically adding new pages"?


Best
Maja
