### PR TITLE
permanent Get Help, modal Disclaimer footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,22 @@
 <footer class="bd-footer py-4 py-md-5 mt-5 bg-body-tertiary">
     <div class="container py-4 py-md-5 px-4 px-md-3 text-body-secondary">
 
+        <div class="row">
+            <div class="col-12 text-center">
+                <h5>Get Help</h5>
+                <p>If you have any further questions about the management and analysis of your microbial research data, please contact us: 
+                <a href="mailto:helpdesk@nfdi4microbiota.de">helpdesk@nfdi4microbiota.de</a> 
+                (by emailing us you agree to the 
+                <a href="https://www.zbmed.de/en/privacy-policy">privacy policy - in German</a> 
+                on our website: 
+                <a href="https://nfdi4microbiota.de/support/helpdesk">Contact</a>). 
+                The legaly non-binding English translation can be found here: 
+                <a href="{{ '/How-We-Operate/privacy-policy-english-translation.html' | relative_url }}">
+                English Translation</a>.
+                </p>
+            </div>
+        </div>
+        
         <div class="row align-items-center">
             <div class="col-3">
                 <a class="d-inline-flex align-items-center mb-2 text-body-emphasis text-decoration-none"
@@ -29,12 +45,11 @@
                             list</a></h5>
                     </div>
                     <div class="col-auto">
-                        <h5><a href="#" data-bs-toggle="modal" data-bs-target="#getHelpModal">Get Help</a></h5>
-                    </div>
                 </div>
             </div>
         </div>
 
+        </div>
     </div>
 </footer>
 
@@ -51,7 +66,7 @@
                     Knowledge Base, it is important to note that our reviewers are not experts in all the topics added,
                     nor are they legal experts.
                     Therefore, errors, inaccuracies, sensitive information and malicious content may slip through the
-                    review process. The reviewers cannot be held responsible for this.
+                    review process. The reviewers and  NFDI4Microbiota cannot be held responsible for this.
                 </p>
                 <p>If you notice anything, thank you for informing us by <a
                         href="https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base/issues/new">adding an
@@ -67,32 +82,5 @@
             </div>
         </div>
     </div>
-</div>
 
-<!-- Get Help Modal -->
-<div class="modal fade" id="getHelpModal" tabindex="-1" aria-labelledby="getHelpModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="getHelpModalLabel">Get Help</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <p>If you have any further questions about the management and analysis of your microbial research data,
-                    please contact us:
-                    <a href="mailto:helpdesk@nfdi4microbiota.de">helpdesk@nfdi4microbiota.de</a>
-                    (by emailing us you agree to the
-                    <a href="https://www.zbmed.de/en/privacy-policy">privacy policy - in German</a>
-                    on our website:
-                    <a href="https://nfdi4microbiota.de/support/helpdesk">Contact</a>).
-                    The legally non-binding English translation can be found here:
-                    <a href="{{ '/How-We-Operate/privacy-policy-english-translation.html' | relative_url }}">English
-                        Translation</a>.
-                </p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
Hi @elhossary, 

thank you for setting up the modal links. Very nice! As discussed during the sprint, we would like to keep the permanently showing Get Help section for outreach purposes as mentioned in #486 

Can you double-check again, please?

I first thought of permanently opening the modal bootstrap container, but then read somewhere that it might break and turn to weird behaviour. So instead I kept the old format and removed the modal Get Help sections.

Best

Maja