### PR TITLE
docs: add TL;DR summary to contributing guide

### DIFF
--- a/docs/_Getting-Started/contributing.md
+++ b/docs/_Getting-Started/contributing.md
@@ -225,6 +225,19 @@ The view corresponds to the left-hand navigation bar on topics featured on the K
 4. Your suggestions will be discussed internally before potential acceptance.
 
 
+## TL;DR
+
+* Fork the repository
+* Create a new branch (`git checkout -b feature/your-feature-name`)
+* Make your changes
+* Commit changes (`git commit -m "your message"`)
+* Push to your fork (`git push origin your-branch`)
+* Open a Pull Request
+
+👉 Keep PRs small and focused
+👉 Follow existing code style
+👉 Add clear descriptions in your PR
+
 ## Contributors
 
 {% include popover.html %}


### PR DESCRIPTION
### Add TL;DR to contributing guide

- Added a concise TL;DR section at the top of CONTRIBUTING.md
- Helps new contributors quickly understand the workflow

Closes #499